### PR TITLE
Add failing memory regression test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "backend"))
+os.environ.setdefault("OPENAI_API_KEY", "test-key")

--- a/tests/test_memory_regression.py
+++ b/tests/test_memory_regression.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import List
+
+from langchain.schema import AIMessage, HumanMessage
+from langgraph.checkpoint.memory import MemorySaver
+
+from app.graphs import main_graph
+
+
+def _collect_content(prompt: str, thread_id: str) -> str:
+    latest = ""
+    for step in main_graph.graph.stream(
+        {"messages": [HumanMessage(content=prompt)]},
+        {"configurable": {"thread_id": thread_id}},
+    ):
+        msgs: List | None = step.get("llm", {}).get("messages")
+        if msgs:
+            latest = msgs[-1].content
+    return latest
+
+
+def test_memory_regression(monkeypatch) -> None:
+    """Assistant should remember earlier turns within the same thread."""
+
+    class FakeLLM:
+        def __init__(self, *_: object, **__: object) -> None:
+            pass
+
+        def invoke(self, messages):
+            joined = " ".join(m.content for m in messages)
+            return AIMessage(content=joined)
+
+    monkeypatch.setattr(main_graph, "ChatOpenAI", FakeLLM)
+    main_graph.graph = main_graph.build_graph(MemorySaver())
+
+    tid = "t42"
+    first = _collect_content("hi", tid)
+    second = _collect_content("again", tid)
+
+    assert first in second

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from langchain.schema import AIMessage, HumanMessage
-from langchain_community.chat_models import ChatOpenAI
 from langgraph.checkpoint.memory import MemorySaver
 
 from app.graphs import main_graph
@@ -10,10 +9,14 @@ from app.graphs import main_graph
 def test_threads(monkeypatch) -> None:
     """Graph should persist messages per thread."""
 
-    def fake_invoke(self, messages):
-        return AIMessage(content="pong")
+    class FakeLLM:
+        def __init__(self, *_: object, **__: object) -> None:
+            pass
 
-    monkeypatch.setattr(ChatOpenAI, "invoke", fake_invoke)
+        def invoke(self, messages):
+            return AIMessage(content="pong")
+
+    monkeypatch.setattr(main_graph, "ChatOpenAI", FakeLLM)
 
     main_graph.graph = main_graph.build_graph(MemorySaver())
 


### PR DESCRIPTION
## Summary
- add regression test showing how memory should be retained across thread runs
- patch thread tests to avoid hitting the network
- prepare test harness with PYTHONPATH and dummy key

## Testing
- `PYTHONPATH=backend OPENAI_API_KEY=dummy pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687972c7a8cc832da424a03e966a06cb