### PR TITLE
Fix conversation continuity via thread_id param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Agent now recalls prior turns when the same `X-Thread-ID` is reused.
+- Conversation continues when the same `thread_id` is passed as a query parameter.
 
 ### Removed
 - Postgres checkpoint backend and related configuration.

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ persists only while the server is running.
 
 Then open http://localhost:8000 to chat with **Jules**.
 The backend will return the generated `X-Thread-ID` header on the very first
-request so that clients can persist it; simply include the same header in all
-subsequent calls to continue the same conversation thread.
+request so that clients can persist it.  Subsequent calls should repeat the
+same ID either via the `X-Thread-ID` header or as a `thread_id` query
+parameter to continue the conversation thread.
 
 ## Docker (single image)
 

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -53,8 +53,12 @@ async def chat_endpoint(
             detail="Message is required",
         )
 
-    # Use header-supplied thread id or create one.
-    thread_id = request.headers.get("X-Thread-ID") or str(uuid4())
+    # Use header- or query-supplied thread id or create one.
+    thread_id = (
+        request.headers.get("X-Thread-ID")
+        or request.query_params.get("thread_id")
+        or str(uuid4())
+    )
 
     graph = request.app.state.graph
 

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import AsyncGenerator, List
 import asyncio
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from langchain.schema import HumanMessage
@@ -19,6 +19,8 @@ from ..config import Settings, get_settings
 
 
 router = APIRouter(prefix="/api")
+
+THREAD_ID_HEADER = "X-Thread-ID"
 
 
 async def _authorize(
@@ -53,12 +55,16 @@ async def chat_endpoint(
             detail="Message is required",
         )
 
-    # Use header- or query-supplied thread id or create one.
-    thread_id = (
-        request.headers.get("X-Thread-ID")
-        or request.query_params.get("thread_id")
-        or str(uuid4())
+    raw_id = request.headers.get(THREAD_ID_HEADER) or request.query_params.get(
+        "thread_id"
     )
+    if raw_id is not None:
+        try:
+            thread_id = str(UUID(raw_id, version=4))
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail="Invalid thread_id") from exc
+    else:
+        thread_id = str(uuid4())
 
     graph = request.app.state.graph
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,8 @@
         "isomorphic-ws": "^5.0.0",
         "next": "14.2.3",
         "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react-dom": "18.2.0",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@types/node": "24.0.14",
@@ -5999,6 +6000,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/which": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "isomorphic-ws": "^5.0.0",
     "next": "14.2.3",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@types/node": "24.0.14",

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import {
   Box,
   Button,
@@ -39,6 +40,12 @@ export function Chat() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
+  const [threadId] = useState(
+    () => localStorage.getItem('julesThreadId') || uuidv4()
+  );
+  useEffect(() => {
+    localStorage.setItem('julesThreadId', threadId);
+  }, [threadId]);
   const eventSourceRef = useRef<EventSource | null>(null);
 
   const sendMessage = () => {
@@ -48,7 +55,9 @@ export function Chat() {
     setInput('');
     setLoading(true);
 
-    const url = `${backendUrl}/api/chat?message=${encodeURIComponent(input)}`;
+    const url =
+      `${backendUrl}/api/chat?thread_id=${threadId}` +
+      `&message=${encodeURIComponent(input)}`;
     const es = new EventSource(url, { withCredentials: false });
 
     eventSourceRef.current = es;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,5 +3,7 @@ import sys
 from pathlib import Path
 
 # Ensure backend modules resolve in tests without installing the package.
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "backend"))
+repo_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / "backend"))
 os.environ.setdefault("OPENAI_API_KEY", "test-key")

--- a/tests/test_thread_id_api.py
+++ b/tests/test_thread_id_api.py
@@ -1,0 +1,50 @@
+import os
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from langchain.schema import AIMessage
+from app.routers import chat as chat_router
+from app.graphs import main_graph
+
+
+def _decode(body: str) -> str:
+    return "".join(
+        line.split("data: ", 1)[1]
+        for line in body.splitlines()
+        if line.startswith("data:")
+    )
+
+
+class EchoLLM:
+    def __init__(self, *_: object, **__: object) -> None:
+        pass
+
+    def invoke(self, messages):
+        return AIMessage(content=" ".join(m.content for m in messages))
+
+
+app = FastAPI()
+app.include_router(chat_router.router)
+
+
+def _setup(monkeypatch):
+    monkeypatch.setattr(main_graph, "ChatOpenAI", EchoLLM)
+    app.state.graph = main_graph.build_graph()
+
+
+def test_query_param_persists_thread(monkeypatch) -> None:
+    _setup(monkeypatch)
+    tid = "123e4567-e89b-12d3-a456-426614174000"
+    with TestClient(app) as client:
+        r1 = client.get(f"/api/chat?thread_id={tid}&message=hello")
+        assert r1.status_code == 200
+        _decode(r1.text)
+        r2 = client.get(f"/api/chat?thread_id={tid}&message=again")
+        body = _decode(r2.text)
+        assert "hello" in body
+
+
+def test_invalid_thread_id(monkeypatch) -> None:
+    _setup(monkeypatch)
+    with TestClient(app) as client:
+        r = client.get("/api/chat?thread_id=bogus&message=hi")
+        assert r.status_code == 400


### PR DESCRIPTION
## Summary
- allow `thread_id` via query parameter when creating a chat
- persist a UUID on the frontend and send it in the query string
- document the new option in the README
- install `uuid` for the Next.js client

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687cd3465fb0832d86de7828809fc28e