### PR TITLE
Fix Next.js build by adding uuid types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Agent now recalls prior turns when the same `X-Thread-ID` is reused.
 - Conversation continues when the same `thread_id` is passed as a query parameter.
+- Added `@types/uuid` to resolve TypeScript build error.
 
 ### Removed
 - Postgres checkpoint backend and related configuration.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@types/node": "24.0.14",
+        "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^6.7.0",
         "@typescript-eslint/parser": "^6.7.0",
         "eslint": "^8.52.0",
@@ -1146,6 +1147,12 @@
       "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.21.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@types/node": "24.0.14",
+    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^6.7.0",
     "@typescript-eslint/parser": "^6.7.0",
     "eslint": "^8.52.0",

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -108,8 +108,9 @@ export function Chat() {
         <TextField
           fullWidth
           value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => {
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setInput(e.target.value)}
+          onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
             if (e.key === 'Enter') {
               e.preventDefault();
               sendMessage();


### PR DESCRIPTION
## Summary
- fix strict typing error for event handlers in Chat.tsx
- add `@types/uuid` dev dependency
- document fix in changelog

## Testing
- `npm run build` (frontend)
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cde355eac832daf1736bf1434ef41