### PR TITLE
Fix Next.js build error

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -40,12 +40,14 @@ export function Chat() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
-  const [threadId] = useState(
-    () => localStorage.getItem('julesThreadId') || uuidv4()
-  );
+  const [threadId, setThreadId] = useState<string>('');
+
   useEffect(() => {
-    localStorage.setItem('julesThreadId', threadId);
-  }, [threadId]);
+    if (typeof window === 'undefined') return;
+    const stored = localStorage.getItem('julesThreadId') || uuidv4();
+    setThreadId(stored);
+    localStorage.setItem('julesThreadId', stored);
+  }, []);
   const eventSourceRef = useRef<EventSource | null>(null);
 
   const sendMessage = () => {


### PR DESCRIPTION
## Summary
- avoid accessing `localStorage` during pre-rendering in `Chat` component

## Testing
- `npm run build` in `frontend`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ce4ebcfb4832d9ce560870a009fd6