### PR TITLE
Integrate Chroma with FastAPI app

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,6 +2,7 @@
 
 CHROMA_HOST=chroma
 CHROMA_PORT=8000
+CHROMA_TIMEOUT_MS=100
 OPENAI_API_KEY=
 # Optional simple bearer token for basic auth. Comment out to disable.
 # JULES_AUTH_TOKEN=my-secret-token

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ An AI-powered chatbot built with LangChain + LangGraph on a FastAPI backend and 
 1. Copy `.env.example` → `.env` and fill in:
    - `OPENAI_API_KEY=<your OpenAI key>` (required)
    - `JULES_AUTH_TOKEN=<optional bearer token>` (commented out by default; leave unset to disable auth)
+   - `CHROMA_TIMEOUT_MS=100` optional request timeout
 2. Install Python deps & run backend:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Then open http://localhost:8000 to chat with **Jules**.
   ]
   ```
 - **GET /api/chat/search?thread_id=<id>&query=<text>**
-  Vector similarity search within a thread backed by Chroma.
+  Vector similarity search within a thread backed by Chroma. Returns a list of
+  objects `[{'text': str, 'distance': float, 'timestamp': float | null, 'role': str | null}]`.
 The backend will return the generated `X-Thread-ID` header on the very first
 request so that clients can persist it.  Subsequent calls should repeat the
 same ID either via the `X-Thread-ID` header or as a `thread_id` query

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Then open http://localhost:8000 to chat with **Jules**.
   Streams chat completions via Server-Sent Events.  On the first request for a new thread,
   the `X-Thread-ID` response header provides the generated session ID.  Include the same
   `thread_id` (query or `X-Thread-ID` header) on subsequent calls to continue the conversation.
+- **POST /api/chat/message**
+  Persist a single chat message to SQLite and Chroma. Parameters `thread_id`, `role`, and `content` are required.
 - **GET /api/chat/history?thread_id=<id>**
   Returns the full conversation history as JSON:
   ```
@@ -67,6 +69,8 @@ Then open http://localhost:8000 to chat with **Jules**.
     ...
   ]
   ```
+- **GET /api/chat/search?thread_id=<id>&query=<text>**
+  Vector similarity search within a thread backed by Chroma.
 The backend will return the generated `X-Thread-ID` header on the very first
 request so that clients can persist it.  Subsequent calls should repeat the
 same ID either via the `X-Thread-ID` header or as a `thread_id` query

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -8,8 +8,13 @@ conversation context using the configured LangGraph checkpoint saver.
 from __future__ import annotations
 
 from typing import AsyncGenerator, List
+import logging
 import asyncio
 from uuid import UUID, uuid4
+import time
+import anyio
+from db.chroma import save_message, StoredMsg
+from db import sqlite
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from langchain.schema import HumanMessage, SystemMessage
@@ -22,6 +27,7 @@ import datetime
 
 router = APIRouter(prefix="/api")
 
+logger = logging.getLogger(__name__)
 THREAD_ID_HEADER = "X-Thread-ID"
 
 
@@ -112,14 +118,14 @@ async def chat_endpoint(
     # Attach the (possibly freshly generated) thread id so clients can persist it.
     return EventSourceResponse(generator(), headers={"X-Thread-ID": thread_id})
 
+
 @router.get("/chat/history")
-async def chat_history(
-    request: Request, settings: Settings = Depends(get_settings)
-):
+async def chat_history(request: Request, settings: Settings = Depends(get_settings)):
     """Return the full message history for a given thread_id."""
     await _authorize(request, settings)
-    raw_id = (request.headers.get(THREAD_ID_HEADER)
-              or request.query_params.get("thread_id"))
+    raw_id = request.headers.get(THREAD_ID_HEADER) or request.query_params.get(
+        "thread_id"
+    )
     if raw_id is None:
         raise HTTPException(status_code=400, detail="thread_id is required")
     try:
@@ -137,60 +143,71 @@ async def chat_history(
             cp = tup.checkpoint
             if isinstance(cp, dict):
                 # channel_values holds per-channel state
-                channel_vals = cp.get('channel_values', {})
-                msgs = channel_vals.get('messages', []) or []
+                channel_vals = cp.get("channel_values", {})
+                msgs = channel_vals.get("messages", []) or []
             else:
-                msgs = getattr(cp, 'messages', []) or []
-    except Exception as e:
+                msgs = getattr(cp, "messages", []) or []
+    except Exception:
         # error loading history, return empty
         msgs = []
     # Convert to serializable form
     result = []
-    from langchain.schema import AIMessage, HumanMessage
+    from langchain.schema import AIMessage
+
     for m in msgs:
         # determine sender and extract timestamp if present
-        sender = 'assistant' if isinstance(m, AIMessage) else 'user'
-        ts = getattr(m, 'additional_kwargs', {}).get('timestamp')
-        entry: dict = {'sender': sender, 'content': m.content}
+        sender = "assistant" if isinstance(m, AIMessage) else "user"
+        ts = getattr(m, "additional_kwargs", {}).get("timestamp")
+        entry: dict = {"sender": sender, "content": m.content}
         if ts is not None:
-            entry['timestamp'] = ts
+            entry["timestamp"] = ts
         result.append(entry)
     return result
+
+
+@router.post("/chat/message")
+async def post_message(
+    request: Request,
+    thread_id: str,
+    role: str,
+    content: str,
+    settings: Settings = Depends(get_settings),
+):
+    """Persist a message and index it in Chroma."""
+
+    await _authorize(request, settings)
+
+    msg = StoredMsg(
+        id=str(uuid4()),
+        thread_id=thread_id,
+        role=role,
+        content=content,
+        ts=time.time(),
+    )
+    await sqlite.insert(sqlite.ChatMessage(**msg.model_dump()))
+    try:
+        await anyio.to_thread.run_sync(save_message, msg)
+    except Exception:
+        # Swallow vector store errors
+        logger.warning("Chroma save failed", exc_info=True)
+    return {"id": msg.id}
 
 
 @router.get("/chat/search")
 async def chat_search(
     request: Request,
-    q: str,
-    settings: Settings = Depends(get_settings)
+    thread_id: str,
+    query: str,
+    settings: Settings = Depends(get_settings),
 ):
-    """Search across all thread histories for messages containing a substring."""
+    """Vector search for messages within *thread_id*."""
+
     await _authorize(request, settings)
-    saver = request.app.state.checkpointer
-    conn = saver.conn  # sqlite3.Connection
-    cur = conn.cursor()
-    # get all thread IDs
-    cur.execute("SELECT DISTINCT thread_id FROM checkpoints")
-    threads = [row[0] for row in cur.fetchall()]
-    results: list[dict] = []
-    from langchain.schema import AIMessage, HumanMessage
-    for tid in threads:
-        tup = saver.get_tuple({"configurable": {"thread_id": tid}})
-        if not tup:
-            continue
-        cp = tup.checkpoint
-        msgs = []
-        if isinstance(cp, dict):
-            channel_vals = cp.get('channel_values', {})
-            msgs = channel_vals.get('messages', []) or []
-        else:
-            msgs = getattr(cp, 'messages', []) or []
-        for m in msgs:
-            if q.lower() in m.content.lower():
-                sender = 'assistant' if isinstance(m, AIMessage) else 'user'
-                ts = getattr(m, 'additional_kwargs', {}).get('timestamp')
-                entry: dict = {'thread_id': tid, 'sender': sender, 'content': m.content}
-                if ts is not None:
-                    entry['timestamp'] = ts
-                results.append(entry)
-    return results
+    from db.chroma import search as chroma_search
+
+    try:
+        hits = chroma_search(thread_id, query, k=8)
+    except Exception:
+        raise HTTPException(status_code=503, detail="vector search unavailable")
+
+    return hits

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -13,7 +13,7 @@ import asyncio
 from uuid import UUID, uuid4
 import time
 import anyio
-from db.chroma import save_message, StoredMsg
+from db.chroma import save_message, StoredMsg, SearchHit
 from db import sqlite
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -193,7 +193,7 @@ async def post_message(
     return {"id": msg.id}
 
 
-@router.get("/chat/search")
+@router.get("/chat/search", response_model=list[SearchHit])
 async def chat_search(
     request: Request,
     thread_id: str,
@@ -206,7 +206,7 @@ async def chat_search(
     from db.chroma import search as chroma_search
 
     try:
-        hits = chroma_search(thread_id, query, k=8)
+        hits = await chroma_search(thread_id, query, k=8)
     except Exception:
         raise HTTPException(status_code=503, detail="vector search unavailable")
 

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,0 +1,4 @@
+from . import chroma
+from . import sqlite
+
+__all__ = ["chroma", "sqlite"]

--- a/db/sqlite.py
+++ b/db/sqlite.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+import aiosqlite
+from pydantic import BaseModel
+
+from jules.logging import trace
+
+_db: Optional[aiosqlite.Connection] = None
+
+
+class ChatMessage(BaseModel):
+    id: str
+    thread_id: str
+    role: str
+    content: str
+    ts: float
+
+
+async def _get_db() -> aiosqlite.Connection:
+    global _db
+    if _db is None:
+        path = Path(os.environ.get("JULES_CHAT_DB", "data/chat.sqlite")).expanduser()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _db = await aiosqlite.connect(path)
+        await _db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS messages (
+                id TEXT PRIMARY KEY,
+                thread_id TEXT,
+                role TEXT,
+                content TEXT,
+                ts REAL
+            )
+            """
+        )
+        await _db.commit()
+    return _db
+
+
+@trace
+async def insert(msg: ChatMessage) -> None:
+    db = await _get_db()
+    await db.execute(
+        "INSERT INTO messages (id, thread_id, role, content, ts) VALUES (?, ?, ?, ?, ?)",
+        (msg.id, msg.thread_id, msg.role, msg.content, msg.ts),
+    )
+    await db.commit()
+
+
+@trace
+async def count() -> int:
+    db = await _get_db()
+    async with db.execute("SELECT COUNT(*) FROM messages") as cur:
+        row = await cur.fetchone()
+    return int(row[0])

--- a/tests/chroma/test_chroma_save_search.py
+++ b/tests/chroma/test_chroma_save_search.py
@@ -44,4 +44,4 @@ def test_chroma_save_search(chroma_fake_embed: None) -> None:
     res = anyio.run(chroma.search, "t1", "hello", 1)
     assert res
     assert res[0].text == "hello"
-    assert res[0].score <= 0.25
+    assert res[0].distance <= 0.25

--- a/tests/chroma/test_chroma_save_search.py
+++ b/tests/chroma/test_chroma_save_search.py
@@ -5,6 +5,7 @@ import time
 from collections.abc import Generator
 
 import chromadb
+import anyio
 import pytest
 
 from db import chroma
@@ -40,7 +41,7 @@ def chroma_fake_embed(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, 
 def test_chroma_save_search(chroma_fake_embed: None) -> None:
     msg = chroma.StoredMsg(thread_id="t1", role="user", content="hello", ts=time.time())
     chroma.save_message(msg)
-    res = chroma.search("t1", "hello", k=1)
+    res = anyio.run(chroma.search, "t1", "hello", 1)
     assert res
-    assert res[0]["content"] == "hello"
-    assert res[0]["score"] <= 0.25
+    assert res[0].text == "hello"
+    assert res[0].score <= 0.25

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,16 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
 # Ensure backend modules resolve in tests without installing the package.
 repo_root = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(repo_root))
 sys.path.insert(0, str(repo_root / "backend"))
 os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+
+@pytest.fixture(autouse=True)
+def _set_log_level(caplog: pytest.LogCaptureFixture) -> None:
+    """Keep test output concise by raising log level to INFO."""
+    caplog.set_level("INFO")

--- a/tests/test_chroma_integration.py
+++ b/tests/test_chroma_integration.py
@@ -11,9 +11,9 @@ from db import chroma, sqlite
 
 
 class DummyEmbed:
-    def __call__(self, texts: list[str]) -> list[list[float]]:
+    def __call__(self, input: list[str]) -> list[list[float]]:
         vecs: list[list[float]] = []
-        for t in texts:
+        for t in input:
             if "apple" in t or "fruit" in t:
                 vecs.append([1.0, 0.0, 0.0])
             else:
@@ -72,14 +72,14 @@ def test_search_semantic(chroma_ephemeral: None) -> None:
         r = client.get("/api/chat/search", params={"thread_id": "t1", "query": "fruit"})
         assert r.status_code == 200
         hits = r.json()
-        assert any(h["content"] == "apple" for h in hits)
+        assert any(h["text"] == "apple" for h in hits)
 
 
 def test_search_chroma_down(monkeypatch: pytest.MonkeyPatch) -> None:
     app = FastAPI()
     app.include_router(chat_router.router)
 
-    def boom(*_: object, **__: object) -> None:
+    async def boom(*_: object, **__: object) -> None:
         raise RuntimeError("down")
 
     monkeypatch.setattr(chroma, "search", boom)

--- a/tests/test_chroma_integration.py
+++ b/tests/test_chroma_integration.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import anyio
+import chromadb
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+
+from app.routers import chat as chat_router
+from db import chroma, sqlite
+
+
+class DummyEmbed:
+    def __call__(self, texts: list[str]) -> list[list[float]]:
+        vecs: list[list[float]] = []
+        for t in texts:
+            if "apple" in t or "fruit" in t:
+                vecs.append([1.0, 0.0, 0.0])
+            else:
+                vecs.append([0.0, 1.0, 0.0])
+        return vecs
+
+
+@pytest.fixture()
+def chroma_ephemeral(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.setattr(
+        chroma.embedding_functions,  # type: ignore[attr-defined]
+        "OpenAIEmbeddingFunction",
+        lambda model_name, api_key: DummyEmbed(),
+    )
+    monkeypatch.setattr(chroma, "HttpClient", lambda **_: chromadb.EphemeralClient())
+    monkeypatch.setenv("CHROMA_HOST", "localhost")
+    monkeypatch.setenv("CHROMA_PORT", "8000")
+    monkeypatch.setenv("JULES_CHAT_DB", str(tmp_path / "chat.sqlite"))
+
+
+async def _sqlite_count() -> int:
+    return await sqlite.count()
+
+
+def test_dual_write(chroma_ephemeral: None) -> None:
+    app = FastAPI()
+    app.include_router(chat_router.router)
+
+    with TestClient(app) as client:
+        before_sql = anyio.run(_sqlite_count)
+        before_chroma = chroma._get_collection().count()
+        r = client.post(
+            "/api/chat/message",
+            params={"thread_id": "t1", "role": "user", "content": "hi"},
+        )
+        assert r.status_code == 200
+        after_sql = anyio.run(_sqlite_count)
+        after_chroma = chroma._get_collection().count()
+        assert after_sql == before_sql + 1
+        assert after_chroma == before_chroma + 1
+
+
+def test_search_semantic(chroma_ephemeral: None) -> None:
+    app = FastAPI()
+    app.include_router(chat_router.router)
+
+    with TestClient(app) as client:
+        client.post(
+            "/api/chat/message",
+            params={"thread_id": "t1", "role": "user", "content": "apple"},
+        )
+        client.post(
+            "/api/chat/message",
+            params={"thread_id": "t1", "role": "user", "content": "fruit"},
+        )
+        r = client.get("/api/chat/search", params={"thread_id": "t1", "query": "fruit"})
+        assert r.status_code == 200
+        hits = r.json()
+        assert any(h["content"] == "apple" for h in hits)
+
+
+def test_search_chroma_down(monkeypatch: pytest.MonkeyPatch) -> None:
+    app = FastAPI()
+    app.include_router(chat_router.router)
+
+    def boom(*_: object, **__: object) -> None:
+        raise RuntimeError("down")
+
+    monkeypatch.setattr(chroma, "search", boom)
+
+    with TestClient(app) as client:
+        r = client.get("/api/chat/search", params={"thread_id": "t1", "query": "x"})
+        assert r.status_code == 503
+        assert r.json() == {"detail": "vector search unavailable"}


### PR DESCRIPTION
## Summary
- dual-write messages to SQLite and Chroma
- add vector search endpoint using Chroma
- expose new `db.sqlite` helper
- configure Chroma client timeout
- document new endpoints
- test integration logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e1e83abbc832daee93c74706e0d1e