### PR TITLE
Accept JSON body for chat message

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Rename this file to `.env` and fill in your secrets.
 
 OPENAI_API_KEY=
+# Chroma vector DB host (Docker service name)
+CHROMA_HOST=chroma
 # Optional simple bearer token for basic auth. Comment out to disable.
 # JULES_AUTH_TOKEN=my-secret-token
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Green-field enforcement via CI and pre-commit.
 
+### Changed
+- `/api/chat/message` now accepts a JSON body. The query parameter version lives under `/api/chat/message/legacy` until v0.5.
+- Default `CHROMA_HOST` is now `chroma` and set in `docker-compose.yml`.
+
 
 ### Fixed
 - Agent now recalls prior turns when the same `X-Thread-ID` is reused.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ An AI-powered chatbot built with LangChain + LangGraph on a FastAPI backend and 
 1. Copy `.env.example` → `.env` and fill in:
    - `OPENAI_API_KEY=<your OpenAI key>` (required)
    - `JULES_AUTH_TOKEN=<optional bearer token>` (commented out by default; leave unset to disable auth)
+   - `CHROMA_HOST=chroma` target Chroma service host
    - `CHROMA_TIMEOUT_MS=100` optional request timeout
 2. Install Python deps & run backend:
 
@@ -59,7 +60,15 @@ Then open http://localhost:8000 to chat with **Jules**.
   the `X-Thread-ID` response header provides the generated session ID.  Include the same
   `thread_id` (query or `X-Thread-ID` header) on subsequent calls to continue the conversation.
 - **POST /api/chat/message**
-  Persist a single chat message to SQLite and Chroma. Parameters `thread_id`, `role`, and `content` are required.
+  Persist a single chat message to SQLite and Chroma. Accepts a JSON body `{"thread_id": "<uuid>", "role": "user|assistant", "content": "<text>"}`.
+  The legacy query-parameter variant remains available at `/api/chat/message/legacy` and will be removed after v0.5.
+  Example:
+  ```bash
+  curl -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"thread_id":"123e4567-e89b-12d3-a456-426614174000","role":"user","content":"hi"}' \
+    http://localhost:8000/api/chat/message
+  ```
 - **GET /api/chat/history?thread_id=<id>**
   Returns the full conversation history as JSON:
   ```

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,0 +1,3 @@
+from .chat import ChatMessageIn
+
+__all__ = ["ChatMessageIn"]

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, UUID4
+
+
+class ChatMessageIn(BaseModel):
+    """Incoming chat message payload."""
+
+    thread_id: UUID4
+    role: str = Field(..., pattern="^(user|assistant)$")
+    content: str = Field(..., max_length=8000)

--- a/db/chroma.py
+++ b/db/chroma.py
@@ -30,7 +30,7 @@ _embedding: EmbeddingFunction[Any] | None = None
 def _get_client() -> ClientAPI:
     global _client
     if _client is None:
-        host = os.environ.get("CHROMA_HOST", "localhost")
+        host = os.environ.get("CHROMA_HOST", "chroma")
         port = int(os.environ.get("CHROMA_PORT", "8000"))
         try:
             timeout_ms = int(os.environ.get("CHROMA_TIMEOUT_MS", "100"))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       dockerfile: Dockerfile
     env_file:
       - .env
+    environment:
+      CHROMA_HOST: chroma
     ports:
       - '8000:8000'
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload


### PR DESCRIPTION
## Summary
- add `ChatMessageIn` schema for POSTing chat messages
- refactor `/api/chat/message` to accept JSON and create a hidden legacy query-param route
- update README and CHANGELOG
- set `CHROMA_HOST=chroma` and expose it in compose and env sample
- adjust Chroma integration tests for the new JSON payload

## Testing
- `ruff check .`
- `black --check backend/app/routers/chat.py backend/app/schemas/chat.py backend/app/schemas/__init__.py tests/test_chroma_integration.py db/chroma.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e34ef4490832dbf86aabcaeab5162