### PR TITLE
Stabilise Chroma: Version Pin + Telemetry Off

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ The `chroma` service acts as the vector store side-car.  Data persists under
 `./.chroma-data` on the host so the index survives container restarts.  Remove
 that directory to wipe all embeddings:
 
+The project pins **Chroma 0.5.23** on both the Python client and the Docker
+image with telemetry disabled so no outbound calls are made.
+
 ```bash
 make clean-vector-store
 ```

--- a/db/chroma.py
+++ b/db/chroma.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 import anyio
 
 from chromadb import HttpClient
+from chromadb.config import Settings
 import httpx
 from chromadb.api import ClientAPI
 from chromadb.api.models.Collection import Collection
@@ -37,7 +38,7 @@ def _get_client() -> ClientAPI:
         except ValueError:
             logger.warning("Invalid CHROMA_TIMEOUT_MS; using default 100 ms")
             timeout_ms = 100
-        _client = HttpClient(host=host, port=port)
+        _client = HttpClient(host=host, port=port, settings=Settings(anonymized_telemetry=False))
         try:
             if hasattr(_client, "_server") and hasattr(_client._server, "_session"):
                 _client._server._session.timeout = httpx.Timeout(timeout_ms / 1000)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - .env
     environment:
       CHROMA_HOST: chroma
+      CHROMA_TELEMETRY_ENABLED: 'false'
     ports:
       - '8000:8000'
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
@@ -19,7 +20,10 @@ services:
       - ./data:/app/data
   # Chroma vector database, empty instance ready for use
   chroma:
-    image: ghcr.io/chroma-core/chroma:latest
+    image: ghcr.io/chroma-core/chroma:0.5.23
+    environment:
+      CHROMA_SERVER_TELEMETRY_ENABLED: 'false'
+      CHROMA_SERVER_AUTH_PROVIDER: none
     volumes:
       # Persist Chroma data locally
       - ./.chroma-data:/chroma/.chroma

--- a/poetry.lock
+++ b/poetry.lock
@@ -210,7 +210,7 @@ version = "25.3.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3"},
     {file = "attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b"},
@@ -3504,6 +3504,26 @@ pluggy = ">=1.5,<2.0"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-docker"
+version = "3.1.1"
+description = "Simple pytest fixtures for Docker and Docker Compose based tests"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pytest-docker-3.1.1.tar.gz", hash = "sha256:2371524804a752aaa766c79b9eee8e634534afddb82597f3b573da7c5d6ffb5f"},
+    {file = "pytest_docker-3.1.1-py3-none-any.whl", hash = "sha256:fd0d48d6feac41f62acbc758319215ec9bb805c2309622afb07c27fa5c5ae362"},
+]
+
+[package.dependencies]
+attrs = ">=19.2.0"
+pytest = ">=4.0,<9.0"
+
+[package.extras]
+docker-compose-v1 = ["docker-compose (>=1.27.3,<2.0)"]
+tests = ["mypy (>=0.500,<2.000)", "pytest-mypy (>=0.10,<1.0)", "pytest-pycodestyle (>=2.0.0,<3.0)", "pytest-pylint (>=0.14.1,<1.0)", "requests (>=2.22.0,<3.0)", "types-requests (>=2.31,<3.0)", "types-setuptools (>=69.0,<70.0)"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -5132,4 +5152,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "1f2375559b3d615790d2ef738e3f087f4f01f65c81f33940f96cf98189455896"
+content-hash = "bf63abe6d659dfdb6bffac74a8dfe91bdb0ee65be9d33ac7f04b5b5224faed0f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ langchain = "0.3.26"
 langchain-openai = "0.3.28"
 langgraph = "0.5.3"
 langchain-community = "0.3.27"
-chromadb = "0.5.23"
+chromadb = "==0.5.23"
 sse-starlette = "1.6.1"
 aiohttp = "3.12.14"
 pydantic-settings = "2.10.1"
@@ -27,6 +27,7 @@ pip-audit = "2.7.1"
 pre-commit = "4.2.0"
 pytest = "8.2.2"
 import-linter = "1.11.1"
+pytest-docker = "3.1.1"
 
 [tool.importlinter]
 contracts = ["importlinter_contracts.greenfield:Contract"]

--- a/tests/chroma/test_save_real.py
+++ b/tests/chroma/test_save_real.py
@@ -1,0 +1,27 @@
+import os
+import pytest
+from db import chroma
+
+pytestmark = pytest.mark.integration
+
+if os.environ.get("ENABLE_INT_TESTS") != "1":
+    pytest.skip("integration tests disabled", allow_module_level=True)
+
+
+@pytest.fixture(scope="session")
+def docker_compose_file(pytestconfig):
+    return os.path.join(pytestconfig.rootdir, "docker-compose.yml")
+
+
+def test_save_real(docker_services):
+    docker_services.start("chroma")
+    port = docker_services.port_for("chroma", 8000)
+    docker_services.wait_for_service("chroma", 8000)
+
+    os.environ["CHROMA_HOST"] = "localhost"
+    os.environ["CHROMA_PORT"] = str(port)
+
+    msg = chroma.StoredMsg(thread_id="i1", role="user", content="hi")
+    chroma.save_message(msg)
+    assert chroma._get_collection().count() == 1
+


### PR DESCRIPTION
## Summary
- pin `chromadb` Python package and Docker image to 0.5.23
- disable Chroma telemetry via compose env vars
- configure client with `anonymized_telemetry=False`
- add integration test for real Chroma container
- document pinned version and telemetry settings

## Testing
- `pre-commit run --files db/chroma.py`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e4dcb4940832d96561ad5edf5b195