### PR TITLE
Persist streaming web-chat messages to Chroma (Option A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Green-field enforcement via CI and pre-commit.
+- Streaming `/api/chat` exchanges are now persisted to Chroma after the
+  assistant reply completes.
 
 ### Changed
 - `/api/chat/message` now accepts a JSON body. The query parameter version lives under `/api/chat/message/legacy` until v0.5.

--- a/README.md
+++ b/README.md
@@ -55,10 +55,12 @@ persists across restarts.
 Then open http://localhost:8000 to chat with **Jules**.
 
 ### API Endpoints
-- **POST /api/chat?thread_id=<id>&message=<text>**
+- **GET /api/chat?thread_id=<id>&message=<text>**
   Streams chat completions via Server-Sent Events.  On the first request for a new thread,
   the `X-Thread-ID` response header provides the generated session ID.  Include the same
   `thread_id` (query or `X-Thread-ID` header) on subsequent calls to continue the conversation.
+  Once the assistant reply finishes streaming, both the user prompt and the response are
+  automatically persisted to SQLite and Chroma so they appear in subsequent searches.
 - **POST /api/chat/message**
   Persist a single chat message to SQLite and Chroma. Accepts a JSON body `{"thread_id": "<uuid>", "role": "user|assistant|system|tool", "content": "<text>"}` (max 32k chars).
   The legacy query-parameter variant remains available at `/api/chat/message/legacy` and will be removed after v0.5.

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -21,6 +21,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from langchain.schema import HumanMessage, SystemMessage
 from pathlib import Path
 from sse_starlette.sse import EventSourceResponse
+from sse_starlette import sse as sse_mod
 
 from ..config import Settings, get_settings
 import datetime
@@ -30,6 +31,67 @@ router = APIRouter(prefix="/api")
 
 logger = logging.getLogger(__name__)
 THREAD_ID_HEADER = "X-Thread-ID"
+
+
+async def stream_chat(prompt: str, thread_id: str, graph) -> AsyncGenerator[str, None]:
+    """Execute the graph and yield the assistant reply token by token.
+
+    The entire response is buffered server-side so we can persist it to
+    SQLite and Chroma after streaming completes.
+    """
+
+    prompts_path = Path(__file__).parent.parent / "prompts" / "root.system.md"
+    try:
+        system_text = prompts_path.read_text(encoding="utf-8").strip()
+    except Exception:
+        system_text = ""
+
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    messages: list = []
+    if system_text:
+        messages.append(SystemMessage(content=system_text))
+    messages.append(HumanMessage(content=prompt, additional_kwargs={"timestamp": now}))
+    user_state = {"messages": messages}
+
+    loop = asyncio.get_running_loop()
+
+    def _run_sync() -> List[str]:
+        latest_tokens: List[str] = []
+        cfg = {"configurable": {"thread_id": thread_id}}
+        for step in graph.stream(user_state, cfg):
+            msgs: List | None = step.get("llm", {}).get("messages")
+            if msgs:
+                latest_tokens = list(msgs[-1].content)
+        return latest_tokens
+
+    tokens: List[str] = await loop.run_in_executor(None, _run_sync)
+    assistant_buffer = "".join(tokens)
+    for ch in tokens:
+        yield ch
+
+    # Persist user and assistant messages after streaming completes
+    user_msg = StoredMsg(
+        id=str(uuid4()),
+        thread_id=thread_id,
+        role="user",
+        content=prompt,
+        ts=time.time(),
+    )
+    assistant_msg = StoredMsg(
+        id=str(uuid4()),
+        thread_id=thread_id,
+        role="assistant",
+        content=assistant_buffer,
+        ts=time.time(),
+    )
+
+    await sqlite.insert(sqlite.ChatMessage(**user_msg.model_dump()))
+    await sqlite.insert(sqlite.ChatMessage(**assistant_msg.model_dump()))
+    try:
+        await anyio.to_thread.run_sync(save_message, user_msg)
+        await anyio.to_thread.run_sync(save_message, assistant_msg)
+    except Exception:
+        logger.warning("Chroma save failed", exc_info=True)
 
 
 async def _authorize(
@@ -76,48 +138,14 @@ async def chat_endpoint(
         thread_id = str(uuid4())
 
     graph = request.app.state.graph
-
-    async def generator() -> AsyncGenerator[str, None]:
-        """Run the *blocking* graph.exec in a thread pool and stream tokens."""
-
-        # Provide the **new** user message only.  LangGraph will automatically
-        # hydrate the previous conversation from the configured checkpointer
-        # (SQLite or in-memory) when a checkpoint for *thread_id* exists.  This
-        # avoids the earlier "checkpoint['v'] is None" migration bug.
-
-        # Load system prompt and include it before the user message
-        prompts_path = Path(__file__).parent.parent / "prompts" / "root.system.md"
-        try:
-            system_text = prompts_path.read_text(encoding="utf-8").strip()
-        except Exception:
-            system_text = ""
-        # Prepare messages: system prompt followed by user message with timestamp
-        now = datetime.datetime.now(datetime.timezone.utc).isoformat()
-        messages: list = []
-        if system_text:
-            messages.append(SystemMessage(content=system_text))
-        messages.append(
-            HumanMessage(content=prompt, additional_kwargs={"timestamp": now})
-        )
-        user_state = {"messages": messages}
-
-        loop = asyncio.get_running_loop()
-
-        def _run_sync() -> List[str]:
-            latest_tokens: List[str] = []
-            cfg = {"configurable": {"thread_id": thread_id}}
-            for step in graph.stream(user_state, cfg):
-                messages: List | None = step.get("llm", {}).get("messages")
-                if messages:
-                    latest_tokens = list(messages[-1].content)
-            return latest_tokens
-
-        tokens: List[str] = await loop.run_in_executor(None, _run_sync)
-        for ch in tokens:
-            yield ch
+    # Reset SSE shutdown event to avoid event-loop cross-talk in tests
+    sse_mod.AppStatus.should_exit_event = None
 
     # Attach the (possibly freshly generated) thread id so clients can persist it.
-    return EventSourceResponse(generator(), headers={"X-Thread-ID": thread_id})
+    return EventSourceResponse(
+        stream_chat(prompt, thread_id, graph),
+        headers={"X-Thread-ID": thread_id},
+    )
 
 
 @router.get("/chat/history")

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import anyio
+import chromadb
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+
+from app.routers import chat as chat_router
+from app.graphs import main_graph
+from db import chroma, sqlite
+
+
+def _decode(body: str) -> str:
+    return "".join(
+        line.split("data: ", 1)[1]
+        for line in body.splitlines()
+        if line.startswith("data:")
+    )
+
+
+class EchoLLM:
+    def __init__(self, *_: object, **__: object) -> None:
+        pass
+
+    def invoke(self, messages):
+        return main_graph.AIMessage(content="pong")
+
+
+@pytest.fixture()
+def chroma_ephemeral(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    class DummyEmbed:
+        def __call__(self, input: list[str]) -> list[list[float]]:
+            return [[0.0, 0.0, 0.0] for _ in input]
+
+    monkeypatch.setattr(
+        chroma.embedding_functions,  # type: ignore[attr-defined]
+        "OpenAIEmbeddingFunction",
+        lambda model_name, api_key: DummyEmbed(),
+    )
+    monkeypatch.setattr(chroma, "HttpClient", lambda **_: chromadb.EphemeralClient())
+    monkeypatch.setenv("CHROMA_HOST", "localhost")
+    monkeypatch.setenv("CHROMA_PORT", "8000")
+    monkeypatch.setenv("JULES_CHAT_DB", str(tmp_path / "chat.sqlite"))
+
+
+def test_stream_persists(
+    chroma_ephemeral: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = FastAPI()
+    app.include_router(chat_router.router)
+
+    monkeypatch.setattr(main_graph, "ChatOpenAI", EchoLLM)
+    app.state.graph = main_graph.build_graph()
+
+    with TestClient(app) as client:
+        before_sql = anyio.run(sqlite.count)
+        before_chroma = chroma._get_collection().count()
+
+        tid = "550e8400-e29b-41d4-a716-446655440010"
+        r = client.get(f"/api/chat?thread_id={tid}&message=hi")
+        assert r.status_code == 200
+        _decode(r.text)
+
+        after_sql = anyio.run(sqlite.count)
+        after_chroma = chroma._get_collection().count()
+
+        assert after_sql == before_sql + 2
+        assert after_chroma == before_chroma + 2


### PR DESCRIPTION
## Summary
- buffer assistant stream and persist both user & assistant turns after SSE completes
- reset SSE shutdown event to avoid cross-loop errors
- add regression test ensuring SSE writes reach Chroma
- document `/api/chat` persistence behaviour
- note change in changelog

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e9121bbd4832d924dbe1e33dfcde2