### PR TITLE
Enable global search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
   assistant reply completes.
 - SSE responses now emit tokens incrementally and write to Chroma concurrently.
   Closes WO-4.
+- Search endpoint now supports global search when `thread_id` is omitted.
 
 ### Changed
 - `/api/chat/message` now accepts a JSON body. The query parameter version lives under `/api/chat/message/legacy` until v0.5.

--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ Then open http://localhost:8000 to chat with **Jules**.
   ]
   ```
 • **GET /api/chat/search?thread_id=<id>&query=<text>**
-  Vector similarity search within a thread backed by Chroma. Returns a list of
-  objects `[{'text': str, 'distance': float, 'timestamp': float | null, 'role': str | null}]`.
+  Vector similarity search backed by Chroma. Omit `thread_id` for a global
+  search. Returns a list of objects `[{'text': str, 'distance': float,
+  'timestamp': float | null, 'role': str | null}]`.
 The backend will return the generated `X-Thread-ID` header on the very first
 request so that clients can persist it.  Subsequent calls should repeat the
 same ID either via the `X-Thread-ID` header or as a `thread_id` query

--- a/tests/chroma/test_chroma_save_search.py
+++ b/tests/chroma/test_chroma_save_search.py
@@ -41,7 +41,7 @@ def chroma_fake_embed(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, 
 def test_chroma_save_search(chroma_fake_embed: None) -> None:
     msg = chroma.StoredMsg(thread_id="t1", role="user", content="hello", ts=time.time())
     chroma.save_message(msg)
-    res = anyio.run(chroma.search, "t1", "hello", 1)
+    res = anyio.run(chroma.search, {"thread_id": "t1"}, "hello", 1)
     assert res
     assert res[0].text == "hello"
     assert res[0].distance <= 0.25

--- a/tests/routers/test_search.py
+++ b/tests/routers/test_search.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import chromadb
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+
+from app.routers import chat as chat_router
+from db import chroma
+
+
+@pytest.fixture()
+def chroma_ephemeral(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    class DummyEmbed:
+        def __call__(self, input: list[str]) -> list[list[float]]:
+            return [[0.0, 0.0, 0.0] for _ in input]
+
+    monkeypatch.setattr(
+        chroma.embedding_functions,  # type: ignore[attr-defined]
+        "OpenAIEmbeddingFunction",
+        lambda model_name, api_key: DummyEmbed(),
+    )
+    monkeypatch.setattr(chroma, "HttpClient", lambda **_: chromadb.EphemeralClient())
+    monkeypatch.setenv("CHROMA_HOST", "localhost")
+    monkeypatch.setenv("CHROMA_PORT", "8000")
+    monkeypatch.setenv("JULES_CHAT_DB", str(tmp_path / "chat.sqlite"))
+
+
+def test_global_search_returns_hits(chroma_ephemeral: None) -> None:
+    app = FastAPI()
+    app.include_router(chat_router.router)
+
+    with TestClient(app) as client:
+        tid1 = "550e8400-e29b-41d4-a716-446655440011"
+        tid2 = "550e8400-e29b-41d4-a716-446655440012"
+        client.post(
+            "/api/chat/message",
+            json={"thread_id": tid1, "role": "user", "content": "hello one"},
+        )
+        client.post(
+            "/api/chat/message",
+            json={"thread_id": tid2, "role": "user", "content": "hello two"},
+        )
+
+        r = client.get("/api/chat/search", params={"query": "hello"})
+        assert r.status_code == 200
+        assert len(r.json()) >= 2
+
+
+def test_thread_search_still_isolated(chroma_ephemeral: None) -> None:
+    app = FastAPI()
+    app.include_router(chat_router.router)
+
+    with TestClient(app) as client:
+        tid1 = "550e8400-e29b-41d4-a716-446655440013"
+        tid2 = "550e8400-e29b-41d4-a716-446655440014"
+        client.post(
+            "/api/chat/message",
+            json={"thread_id": tid1, "role": "user", "content": "alpha"},
+        )
+        client.post(
+            "/api/chat/message",
+            json={"thread_id": tid2, "role": "user", "content": "beta"},
+        )
+
+        r = client.get("/api/chat/search", params={"thread_id": tid1, "query": "alpha"})
+        assert r.status_code == 200
+        hits = r.json()
+        assert len(hits) == 1
+        assert hits[0]["text"] == "alpha"


### PR DESCRIPTION
## Summary
- search endpoint: thread_id optional and global search support
- update changelog and docs
- adjust Chroma helper and existing tests
- add tests covering global & scoped search

## Testing
- `USE_EMBEDDINGS=1 poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fae6574a4832d9b70378143aae743