### PR TITLE
Streamline search payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 * BREAKING: `/api/chat/search` no longer returns `distance`. `similarity` field is now rounded to 4 decimals.
+* Clients that need raw distance should compute it client-side or read it from earlier API versions.
 
 ### Added
 - Green-field enforcement via CI and pre-commit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+* BREAKING: `/api/chat/search` no longer returns `distance`. `similarity` field is now rounded to 4 decimals.
+
 ### Added
 - Green-field enforcement via CI and pre-commit.
 - Streaming `/api/chat` exchanges are now persisted to Chroma after the

--- a/README.md
+++ b/README.md
@@ -83,14 +83,16 @@ Then open http://localhost:8000 to chat with **Jules**.
   ```
 • **GET /api/chat/search?thread_id=<id>&query=<text>**
   Vector similarity search backed by Chroma. Omit `thread_id` for a global
-  search. Each hit includes a `similarity` score (rounded to 4 decimals) and may be filtered via
-  `min_similarity` (0-1). Example:
+  search. Each hit includes a `similarity` score (0–1, higher means closer)
+  rounded to 4 decimals and may be filtered via `min_similarity`. Example:
 
 ```
 /api/chat/search?query=hello&min_similarity=0.8
 ```
 
-Returns `[{'text': 'hello', 'similarity': 0.63,
+Similarity ranges 0–1 (higher = closer).
+
+Returns `[{'text': 'hello', 'similarity': 0.6476,
 'timestamp': 1620000000.0, 'role': 'user'}]`.
 The backend will return the generated `X-Thread-ID` header on the very first
 request so that clients can persist it.  Subsequent calls should repeat the

--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ Then open http://localhost:8000 to chat with **Jules**.
   ```
 • **GET /api/chat/search?thread_id=<id>&query=<text>**
   Vector similarity search backed by Chroma. Omit `thread_id` for a global
-  search. Each hit includes a `similarity` score and may be filtered via
+  search. Each hit includes a `similarity` score (rounded to 4 decimals) and may be filtered via
   `min_similarity` (0-1). Example:
 
 ```
 /api/chat/search?query=hello&min_similarity=0.8
 ```
 
-Returns `[{'text': 'hello', 'distance': 0.25, 'similarity': 0.63,
+Returns `[{'text': 'hello', 'similarity': 0.63,
 'timestamp': 1620000000.0, 'role': 'user'}]`.
 The backend will return the generated `X-Thread-ID` header on the very first
 request so that clients can persist it.  Subsequent calls should repeat the

--- a/db/chroma.py
+++ b/db/chroma.py
@@ -83,12 +83,11 @@ class StoredMsg(BaseModel):
 
 
 class SearchHit(BaseModel):
-    """Vector search result."""
+    """Vector search result without raw distance."""
 
     text: str
-    distance: float = Field(..., description="Cosine distance; lower is more similar")
-    similarity: float | None = Field(
-        None, ge=0.0, le=1.0, description="Monotonic similarity derived from distance"
+    similarity: float = Field(
+        ..., ge=0.0, le=1.0, description="Monotonic similarity derived from distance"
     )
     ts: float | None = None
     role: str | None = None
@@ -121,7 +120,8 @@ async def search(
 ) -> list[SearchHit]:
     """Return the closest messages to *query* filtered by *where*.
 
-    Results include ``similarity`` in addition to raw ``distance``.
+    Each hit carries a ``similarity`` score only; the raw distance is not
+    returned.
     """
 
     try:
@@ -156,7 +156,6 @@ async def search(
         results.append(
             SearchHit(
                 text=doc,
-                distance=dist,
                 similarity=similarity,
                 ts=meta.get("ts"),
                 role=meta.get("role"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jules"
-version = "0.1.0"
+version = "0.2.0"
 description = ""
 authors = []
 

--- a/tests/chroma/test_chroma_save_search.py
+++ b/tests/chroma/test_chroma_save_search.py
@@ -16,6 +16,9 @@ def chroma_fake_embed(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, 
     """Patch embedding to deterministic vectors and HttpClient."""
 
     class DummyEmbed:
+        def name(self) -> str:
+            return "dummy"
+
         def __init__(self) -> None:
             pass
 
@@ -44,5 +47,4 @@ def test_chroma_save_search(chroma_fake_embed: None) -> None:
     res = anyio.run(chroma.search, {"thread_id": "t1"}, "hello", 1)
     assert res
     assert res[0].text == "hello"
-    assert res[0].distance <= 0.25
     assert 0.0 <= (res[0].similarity or 0.0) <= 1.0

--- a/tests/routers/test_search.py
+++ b/tests/routers/test_search.py
@@ -90,7 +90,7 @@ def test_similarity_field_present(chroma_ephemeral: None) -> None:
         assert hits
         hit = hits[0]
         assert "similarity" in hit
-        assert len(str(hit["similarity"]).split(".")[1]) <= 4
+        assert round(hit["similarity"], 4) == hit["similarity"]
         assert "distance" not in hit
         assert 0.0 <= hit["similarity"] <= 1.0
 

--- a/tests/routers/test_search.py
+++ b/tests/routers/test_search.py
@@ -12,6 +12,9 @@ from db import chroma
 @pytest.fixture()
 def chroma_ephemeral(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     class DummyEmbed:
+        def name(self) -> str:
+            return "dummy"
+
         def __call__(self, input: list[str]) -> list[list[float]]:
             return [[0.0, 0.0, 0.0] for _ in input]
 
@@ -85,7 +88,11 @@ def test_similarity_field_present(chroma_ephemeral: None) -> None:
         assert r.status_code == 200
         hits = r.json()
         assert hits
-        assert 0.0 <= hits[0]["similarity"] <= 1.0
+        hit = hits[0]
+        assert "similarity" in hit
+        assert len(str(hit["similarity"]).split(".")[1]) <= 4
+        assert "distance" not in hit
+        assert 0.0 <= hit["similarity"] <= 1.0
 
 
 def test_min_similarity_filters(chroma_ephemeral: None) -> None:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -30,6 +30,9 @@ class ChunkGraph:
 @pytest.fixture()
 def chroma_ephemeral(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     class DummyEmbed:
+        def name(self) -> str:
+            return "dummy"
+
         def __call__(self, input: list[str]) -> list[list[float]]:
             return [[0.0, 0.0, 0.0] for _ in input]
 

--- a/tests/test_chroma_integration.py
+++ b/tests/test_chroma_integration.py
@@ -11,6 +11,9 @@ from db import chroma, sqlite
 
 
 class DummyEmbed:
+    def name(self) -> str:
+        return "dummy"
+
     def __call__(self, input: list[str]) -> list[list[float]]:
         vecs: list[list[float]] = []
         for t in input:


### PR DESCRIPTION
## Summary
- drop distance from `/api/chat/search` results
- round similarity values to 4 decimal places
- update docs and changelog
- bump version to 0.2.0
- adjust tests and helpers for new payload

## Testing
- `pre-commit run --files CHANGELOG.md README.md backend/app/routers/chat.py db/chroma.py pyproject.toml tests/chroma/test_chroma_save_search.py tests/routers/test_search.py tests/test_chat.py tests/test_chroma_integration.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fbf7dd87c832d9e796a1be6ac4e80