### PR TITLE
Add HTTP-based ChromaSearchTool

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# Jules Documentation
+
+Welcome to the Jules project docs.

--- a/docs/tools/search_tool.md
+++ b/docs/tools/search_tool.md
@@ -1,0 +1,11 @@
+# ChromaSearchTool
+
+This tool calls the `/api/chat/search` endpoint over HTTP.
+
+Set `JULES_API_BASE` to point at the backend if not `http://localhost:8000`.
+
+Example wiring with LangGraph:
+```python
+from jules.tools import ChromaSearchTool
+search = ChromaSearchTool()
+```

--- a/jules/tools/__init__.py
+++ b/jules/tools/__init__.py
@@ -1,0 +1,3 @@
+from .search_tool import ChromaSearchTool, SearchResult
+
+__all__ = ["ChromaSearchTool", "SearchResult"]

--- a/jules/tools/search_tool.py
+++ b/jules/tools/search_tool.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import List, Optional
+import os
+
+import httpx
+
+from jules.logging import trace
+
+API_BASE = os.getenv("JULES_API_BASE", "http://localhost:8000")
+
+
+@dataclass
+class SearchResult:
+    text: str
+    similarity: float
+    role: str
+    ts: float
+
+
+class ChromaSearchTool:
+    """Retrieve the *k* most relevant chat messages via the ``/api/chat/search`` endpoint.
+
+    Args:
+        query: Natural-language search string.
+        k: Number of results to return (default 5).
+        thread_id: Restrict search to a conversation UUID.
+        timeout: Network timeout in seconds (default 10).
+
+    Returns:
+        List[SearchResult] sorted by ``similarity`` desc (0-1).
+
+    Example (agent call JSON):
+        ``{"query": "SIEM licensing", "k": 3}``
+    """
+
+    def __init__(self, timeout: int = 10) -> None:
+        self.timeout = timeout
+
+    @trace
+    async def __call__(
+        self, query: str, k: int = 5, thread_id: Optional[str] = None
+    ) -> List[SearchResult]:
+        params: dict[str, str | int] = {"q": query, "k": k}
+        if thread_id:
+            params["thread_id"] = thread_id
+
+        async with httpx.AsyncClient(base_url=API_BASE, timeout=self.timeout) as client:
+            resp = await client.get("/api/chat/search", params=params)
+            resp.raise_for_status()
+
+        hits = resp.json()
+        return [SearchResult(**hit) for hit in hits]

--- a/jules/tools/search_tool.py
+++ b/jules/tools/search_tool.py
@@ -19,7 +19,7 @@ class SearchResult:
 
 
 class ChromaSearchTool:
-    """Retrieve the *k* most relevant chat messages via the ``/api/chat/search`` endpoint.
+    """Retrieve the *k* most relevant chat messages via the **/api/chat/search** endpoint.
 
     Args:
         query: Natural-language search string.
@@ -28,10 +28,10 @@ class ChromaSearchTool:
         timeout: Network timeout in seconds (default 10).
 
     Returns:
-        List[SearchResult] sorted by ``similarity`` desc (0-1).
+        List[SearchResult] sorted by `similarity` desc (0-1).
 
     Example (agent call JSON):
-        ``{"query": "SIEM licensing", "k": 3}``
+        {"query": "SIEM licensing", "k": 3}
     """
 
     def __init__(self, timeout: int = 10) -> None:

--- a/jules/tools/search_tool.py
+++ b/jules/tools/search_tool.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import List, Optional
 import os
 
-import httpx
+import httpx  # type: ignore[import-not-found]
 
 from jules.logging import trace
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,6 @@
+site_name: Jules
+nav:
+  - Home: index.md
+  - CI: ci-greenfield.md
+  - Tools:
+      - Search Tool: tools/search_tool.md

--- a/poetry.lock
+++ b/poetry.lock
@@ -173,7 +173,7 @@ version = "4.9.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c"},
     {file = "anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028"},
@@ -1311,7 +1311,7 @@ version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
@@ -1367,7 +1367,7 @@ version = "1.0.9"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
     {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
@@ -1441,14 +1441,14 @@ test = ["Cython (>=0.29.24)"]
 
 [[package]]
 name = "httpx"
-version = "0.28.1"
+version = "0.27.0"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
-    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
-    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
+    {file = "httpx-0.27.0-py3-none-any.whl", hash = "sha256:71d5465162c13681bff01ad59b2cc68dd838ea1f10e51574bac27103f00c91a5"},
+    {file = "httpx-0.27.0.tar.gz", hash = "sha256:a0cb88a46f32dc874e04ee956e4c2764aba2aa228f650b06788ba6bda2962ab5"},
 ]
 
 [package.dependencies]
@@ -1456,13 +1456,13 @@ anyio = "*"
 certifi = "*"
 httpcore = "==1.*"
 idna = "*"
+sniffio = "*"
 
 [package.extras]
 brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
 cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
-zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "httpx-sse"
@@ -3777,6 +3777,21 @@ files = [
 requests = ">=2.0.1,<3.0.0"
 
 [[package]]
+name = "respx"
+version = "0.21.1"
+description = "A utility for mocking out the Python HTTPX and HTTP Core libraries."
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "respx-0.21.1-py2.py3-none-any.whl", hash = "sha256:05f45de23f0c785862a2c92a3e173916e8ca88e4caad715dd5f68584d6053c20"},
+    {file = "respx-0.21.1.tar.gz", hash = "sha256:0bd7fe21bfaa52106caa1223ce61224cf30786985f17c63c5d71eff0307ee8af"},
+]
+
+[package.dependencies]
+httpx = ">=0.21.0"
+
+[[package]]
 name = "rich"
 version = "14.0.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
@@ -3861,7 +3876,7 @@ version = "1.3.1"
 description = "Sniff out which async library your code is running under"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
     {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
@@ -5153,4 +5168,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "1a9a11791d92bafe9d43753b3cebd9d82924dcd770d01cd0e2621d00fa722077"
+content-hash = "f6f6895fc129d56ebc0cc6f8ec1131cab84f30236ff24a8a91ede2f75086001c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ chromadb = "==0.5.23"
 sse-starlette = "1.6.1"
 aiohttp = "3.12.14"
 pydantic-settings = "2.10.1"
+httpx = "0.27.0"
 starlette = "0.47.2"
 langgraph-checkpoint-sqlite = "2.0.10"
 setuptools = "78.1.1"
@@ -28,6 +29,7 @@ pre-commit = "4.2.0"
 pytest = "8.2.2"
 import-linter = "1.11.1"
 pytest-docker = "3.1.1"
+respx = "0.21.1"
 
 [tool.importlinter]
 contracts = ["importlinter_contracts.greenfield:Contract"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,3 +15,9 @@ os.environ.setdefault("OPENAI_API_KEY", "test-key")
 def _set_log_level(caplog: pytest.LogCaptureFixture) -> None:
     """Keep test output concise by raising log level to INFO."""
     caplog.set_level("INFO")
+
+
+@pytest.fixture(scope="session")
+def anyio_backend() -> str:
+    """Run async tests with asyncio backend only."""
+    return "asyncio"

--- a/tests/tools/test_search_tool.py
+++ b/tests/tools/test_search_tool.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from jules.tools import ChromaSearchTool
+
+
+FIXTURE = [
+    {"text": "dummy 1", "similarity": 0.92, "role": "user", "ts": 1},
+    {"text": "dummy 2", "similarity": 0.90, "role": "assistant", "ts": 2},
+]
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_happy_path(anyio_backend: str = "asyncio") -> None:
+    route = respx.get("http://localhost:8000/api/chat/search").mock(
+        return_value=httpx.Response(200, json=FIXTURE)
+    )
+    tool = ChromaSearchTool()
+    results = await tool("foo", k=2)
+    assert route.called
+    assert len(results) == 2
+    assert results[0].similarity == 0.92
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_thread_filter_param(anyio_backend: str = "asyncio") -> None:
+    respx.get("http://localhost:8000/api/chat/search").mock(
+        return_value=httpx.Response(200, json=FIXTURE)
+    )
+    tool = ChromaSearchTool()
+    await tool("foo", thread_id="abc")
+    last_request = respx.calls.last.request
+    assert "thread_id=abc" in str(last_request.url)
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_http_error(anyio_backend: str = "asyncio") -> None:
+    respx.get("http://localhost:8000/api/chat/search").mock(
+        return_value=httpx.Response(404)
+    )
+    tool = ChromaSearchTool()
+    with pytest.raises(httpx.HTTPStatusError):
+        await tool("oops")

--- a/tests/tools/test_search_tool.py
+++ b/tests/tools/test_search_tool.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import httpx
+import httpx  # type: ignore[import-not-found]
 import pytest
-import respx
+import respx  # type: ignore[import-not-found]
 
 from jules.tools import ChromaSearchTool
 
@@ -14,7 +14,7 @@ FIXTURE = [
 
 
 @pytest.mark.anyio("asyncio")
-@respx.mock
+@respx.mock  # type: ignore[misc]
 async def test_happy_path() -> None:
     route = respx.get("http://localhost:8000/api/chat/search").mock(
         return_value=httpx.Response(200, json=FIXTURE)
@@ -27,7 +27,7 @@ async def test_happy_path() -> None:
 
 
 @pytest.mark.anyio("asyncio")
-@respx.mock
+@respx.mock  # type: ignore[misc]
 async def test_thread_filter_param() -> None:
     respx.get("http://localhost:8000/api/chat/search").mock(
         return_value=httpx.Response(200, json=FIXTURE)
@@ -39,7 +39,7 @@ async def test_thread_filter_param() -> None:
 
 
 @pytest.mark.anyio("asyncio")
-@respx.mock
+@respx.mock  # type: ignore[misc]
 async def test_http_error() -> None:
     respx.get("http://localhost:8000/api/chat/search").mock(
         return_value=httpx.Response(404)

--- a/tests/tools/test_search_tool.py
+++ b/tests/tools/test_search_tool.py
@@ -13,9 +13,9 @@ FIXTURE = [
 ]
 
 
-@pytest.mark.anyio
+@pytest.mark.anyio("asyncio")
 @respx.mock
-async def test_happy_path(anyio_backend: str = "asyncio") -> None:
+async def test_happy_path() -> None:
     route = respx.get("http://localhost:8000/api/chat/search").mock(
         return_value=httpx.Response(200, json=FIXTURE)
     )
@@ -26,9 +26,9 @@ async def test_happy_path(anyio_backend: str = "asyncio") -> None:
     assert results[0].similarity == 0.92
 
 
-@pytest.mark.anyio
+@pytest.mark.anyio("asyncio")
 @respx.mock
-async def test_thread_filter_param(anyio_backend: str = "asyncio") -> None:
+async def test_thread_filter_param() -> None:
     respx.get("http://localhost:8000/api/chat/search").mock(
         return_value=httpx.Response(200, json=FIXTURE)
     )
@@ -38,9 +38,9 @@ async def test_thread_filter_param(anyio_backend: str = "asyncio") -> None:
     assert "thread_id=abc" in str(last_request.url)
 
 
-@pytest.mark.anyio
+@pytest.mark.anyio("asyncio")
 @respx.mock
-async def test_http_error(anyio_backend: str = "asyncio") -> None:
+async def test_http_error() -> None:
     respx.get("http://localhost:8000/api/chat/search").mock(
         return_value=httpx.Response(404)
     )


### PR DESCRIPTION
## Summary
- create `ChromaSearchTool` for HTTP search
- document the tool and wire mkdocs
- add tests for the new tool
- update dependencies for `httpx` and `respx`

## Testing
- `ruff check tests/tools/test_search_tool.py jules/tools/search_tool.py`
- `black jules/tools/search_tool.py tests/tools/test_search_tool.py --check`
- `mypy --strict jules/tools/search_tool.py tests/tools/test_search_tool.py`
- `pytest tests/tools/test_search_tool.py -q`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68800c933a98832da16a454cb4dea380