### PR TITLE
Add retrieval augmented graph

### DIFF
--- a/config/agents.toml
+++ b/config/agents.toml
@@ -1,0 +1,7 @@
+[retrieval_agent]
+model = "gpt-4o-mini"
+top_k = 5
+max_tokens_packet = 150
+
+[jules]
+model = "gpt-4o"

--- a/docs/architecture/graph.md
+++ b/docs/architecture/graph.md
@@ -1,0 +1,13 @@
+# Graph Architecture
+
+```mermaid
+graph TD
+    UA([User msg]) --> R1[retrieval_agent]
+    R1 -->|search?| S{search?}
+    S -- NO_SEARCH --> J[jules]
+    S -- search --> CS[chroma_search]
+    CS --> R2[retrieval_agent]
+    R2 --> J
+```
+
+`config/agents.toml` controls the models, `top_k`, and info packet length at runtime.

--- a/jules/config.py
+++ b/jules/config.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tomllib
+
+_cfg_cache: dict | None = None
+
+
+def get_agent_cfg() -> dict:
+    """Return agent configuration loaded from ``config/agents.toml``."""
+    global _cfg_cache
+    if _cfg_cache is None:
+        path = Path(__file__).parent.parent / "config" / "agents.toml"
+        _cfg_cache = tomllib.loads(path.read_text())
+    return _cfg_cache

--- a/prompts/jules.txt
+++ b/prompts/jules.txt
@@ -1,0 +1,7 @@
+### Context
+{{ info_packet }}
+
+### User
+{{ user_msg }}
+
+Respond helpfully and expand details if needed.

--- a/prompts/retrieval_agent.txt
+++ b/prompts/retrieval_agent.txt
@@ -1,0 +1,10 @@
+You are the Retrieval Agent.
+Task PHASE 1 (no context yet):
+  • If you need to look something up, emit a JSON function-call:
+      name="chroma_search", args={{"query": <user_msg>, "k": {top_k}}}
+  • If no lookup required, output "NO_SEARCH".
+
+Task PHASE 2 (you now have `retrieval`):
+  • Summarise the key facts in ≤ {{max_tokens}} tokens.
+  • Reply as:
+      INFO_PACKET: <bullet list / markdown>

--- a/src/jules/graph/main_v6.py
+++ b/src/jules/graph/main_v6.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TypedDict
+
+from langgraph.graph import StateGraph
+
+try:  # newer langgraph
+    from langgraph.nodes import LLMNode, ToolNode  # type: ignore
+except Exception:  # fallback for older versions
+    from langgraph.prebuilt.tool_node import ToolNode  # type: ignore
+
+    class LLMNode:  # pragma: no cover - placeholder
+        def __init__(self, *_: object, **__: object) -> None:
+            raise RuntimeError("LLMNode unavailable")
+
+
+from jules.tools import ChromaSearchTool, SearchResult
+from jules.config import get_agent_cfg
+
+cfg = get_agent_cfg()
+
+
+class ChatState(TypedDict, total=False):
+    """State shared across graph nodes."""
+
+    user_msg: str
+    search_call: dict
+    retrieval: list[SearchResult]
+    info_packet: str
+    assistant_reply: str
+
+
+# --- Tool -------------------------------------------------
+search_tool = ChromaSearchTool()
+SEARCH_NODE = ToolNode([search_tool.__call__], name="chroma_search")
+
+# --- Retrieval Agent -------------------------------------
+retrieval_llm = LLMNode(
+    model_name=cfg["retrieval_agent"]["model"],
+    system_prompt=(
+        Path("prompts/retrieval_agent.txt")
+        .read_text()
+        .format(
+            top_k=cfg["retrieval_agent"]["top_k"],
+            max_tokens=cfg["retrieval_agent"]["max_tokens_packet"],
+        )
+    ),
+)
+
+# --- Jules ------------------------------------------------
+jules_llm = LLMNode(
+    model_name=cfg["jules"]["model"],
+    system_prompt=Path("prompts/jules.txt").read_text(),
+)
+
+
+def route_after_retrieval(result: dict) -> str:
+    """Route to tool when the LLM emitted a function call."""
+
+    return "tool" if result.get("type") == "function_call" else "skip"
+
+
+def build_graph() -> StateGraph[ChatState]:
+    """Construct the retrieval-augmented conversation graph."""
+
+    sg: StateGraph[ChatState] = StateGraph(ChatState)
+    sg.add_node("retrieval_agent", retrieval_llm)
+    sg.add_node("chroma_search", SEARCH_NODE)
+    sg.set_entry_point("retrieval_agent")
+    sg.add_node("jules", jules_llm)
+
+    sg.add_conditional_edges(
+        "retrieval_agent",
+        route_after_retrieval,
+        {"tool": "chroma_search", "skip": "jules"},
+    )
+    sg.add_edge("chroma_search", "retrieval_agent")
+    sg.add_edge("retrieval_agent", "jules")
+    sg.set_finish_point("jules")
+    return sg.compile()

--- a/tests/graph/test_retrieval_pipeline.py
+++ b/tests/graph/test_retrieval_pipeline.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+import sys
+import types
+
+from langgraph.prebuilt.tool_node import ToolNode
+
+
+class DummyLLM:
+    def __init__(self, outputs: list[dict]) -> None:
+        self.outputs = outputs
+
+    async def __call__(self, _state: dict, *a: object, **k: object) -> dict:
+        return self.outputs.pop(0)
+
+
+class FakeLLMNode(DummyLLM):
+    def __init__(self, *a, **k):
+        super().__init__([])
+
+    async def __call__(self, _state: dict, *_: object, **__: object) -> dict:
+        return self.outputs.pop(0)
+
+
+@pytest.mark.anyio("asyncio")
+async def test_no_search_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy_nodes = types.SimpleNamespace(LLMNode=FakeLLMNode, ToolNode=ToolNode)
+    monkeypatch.setitem(sys.modules, "langgraph.nodes", dummy_nodes)
+    from src.jules.graph import main_v6
+
+    retrieval = DummyLLM([{"content": "NO_SEARCH"}])
+    jules = DummyLLM([{"assistant_reply": "hi"}])
+    monkeypatch.setattr(main_v6, "retrieval_llm", retrieval)
+    monkeypatch.setattr(main_v6, "jules_llm", jules)
+    graph = main_v6.build_graph()
+    steps = []
+    async for step in graph.astream({"user_msg": "Hi"}):
+        steps.append(step)
+    assert steps[0]["retrieval_agent"]["content"] == "NO_SEARCH"
+    assert steps[-1]["jules"]["assistant_reply"] == "hi"
+
+
+DUMMY_DOCS = [
+    {"text": "d1", "similarity": 0.9, "role": "assistant", "ts": 1},
+    {"text": "d2", "similarity": 0.8, "role": "user", "ts": 2},
+    {"text": "d3", "similarity": 0.7, "role": "user", "ts": 3},
+]
+
+
+@pytest.mark.anyio("asyncio")
+@respx.mock  # type: ignore[misc]
+async def test_search_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy_nodes = types.SimpleNamespace(LLMNode=FakeLLMNode, ToolNode=ToolNode)
+    monkeypatch.setitem(sys.modules, "langgraph.nodes", dummy_nodes)
+    from src.jules.graph import main_v6
+
+    route = respx.get("http://localhost:8000/api/chat/search").mock(
+        return_value=httpx.Response(200, json=DUMMY_DOCS)
+    )
+    retrieval = DummyLLM(
+        [
+            {
+                "type": "function_call",
+                "name": "chroma_search",
+                "args": {"query": "What is SIEM?", "k": 5},
+            },
+            {"info_packet": "INFO_PACKET: summary"},
+        ]
+    )
+    jules = DummyLLM([{"assistant_reply": "The answer"}])
+    monkeypatch.setattr(main_v6, "retrieval_llm", retrieval)
+    monkeypatch.setattr(main_v6, "jules_llm", jules)
+    graph = main_v6.build_graph()
+    steps = []
+    async for step in graph.astream({"user_msg": "What is SIEM?"}):
+        steps.append(step)
+    assert steps[0]["retrieval_agent"]["type"] == "function_call"
+    assert route.called
+    assert "INFO_PACKET" in steps[2]["retrieval_agent"]["info_packet"]
+    assert steps[-1]["jules"]["assistant_reply"] == "The answer"


### PR DESCRIPTION
## Summary
- load agent models from config/agents.toml
- create retrieval Agent prompts and graph pipeline
- document updated graph architecture
- add tests for retrieval pipeline

## Testing
- `ruff check src/jules/graph/main_v6.py tests/graph/test_retrieval_pipeline.py jules/config.py`
- `pytest tests/graph/test_retrieval_pipeline.py tests/tools/test_search_tool.py -q` *(fails: ValueError during graph build)*


------
https://chatgpt.com/codex/tasks/task_e_6880188e2eb0832dad058f069bc58cdd