### PR TITLE
Add global debug mode and logging overlay

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,13 @@ jobs:
       - name: Start services
         run: docker compose up -d chroma
       - name: Run tests
+        env:
+          JULES_DEBUG: "0"
         run: poetry run pytest -m "not slow"
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs
+          path: logs/*.jsonl
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The 1.0 release ships a retrieval-aware RAG pipeline.  A lightweight GPT-4o-mini
 • High-level write-up: [`docs/arch/overview_rag.md`](docs/arch/overview_rag.md)  
 • Mermaid sequence diagram: [`docs/arch/next_gen_graph.md`](docs/arch/next_gen_graph.md)
 
+• Debugging guide: [`docs/development/debugging.md`](docs/development/debugging.md)
+
 ## Project layout
 
 ```

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 from dotenv import load_dotenv
 from pydantic_settings import BaseSettings  # type: ignore
-from pydantic import Field, conint, confloat  # type: ignore
+from pydantic import Field, conint, confloat, validator  # type: ignore
 
 # Load variables from a .env file if present
 load_dotenv(dotenv_path=Path(__file__).resolve().parents[2] / ".env")
@@ -41,6 +41,15 @@ class Settings(BaseSettings):
     SEARCH_MMR_OVERSAMPLE: conint(ge=1) = Field(4, env="SEARCH_MMR_OVERSAMPLE")
     # λ ∈ [0,1] – 0→novelty-only, 1→relevance-only.
     SEARCH_MMR_LAMBDA: confloat(ge=0.0, le=1.0) = Field(0.5, env="SEARCH_MMR_LAMBDA")
+
+    debug: bool = Field(False, alias="JULES_DEBUG")
+
+    @validator("debug", pre=True)
+    def _boolify(cls, v: str | bool) -> bool:  # noqa: D401
+        """Parse truthy strings like '1', 'true', 'yes'."""
+        if isinstance(v, bool):
+            return v
+        return str(v).lower() in {"1", "true", "yes"}
 
     class Config:
         case_sensitive = False

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi import Depends, HTTPException, Request, status
 
 from .config import Settings, get_settings
+from jules.logging import configure_logging
 
 # `memory.py` lives at project root.  Use absolute import so it works regardless
 # of where the `app` package is located on the import path (Docker image copies
@@ -17,6 +18,8 @@ from .graphs.next_gen import build_graph
 from .routers import chat as chat_router
 
 
+settings = get_settings()
+configure_logging(settings.debug)
 app = FastAPI(title="Jules API", version="1.0.0")
 
 

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -1,0 +1,19 @@
+import os
+import typer
+
+app = typer.Typer(add_completion=False)
+
+
+@app.command()
+def run_server(
+    debug: bool = typer.Option(False, "--debug/--no-debug", help="Enable TRACE logging")
+) -> None:
+    """Start the FastAPI development server."""
+    os.environ["JULES_DEBUG"] = "1" if debug else "0"
+    import uvicorn
+
+    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True)
+
+
+if __name__ == "__main__":
+    app()

--- a/db/chroma.py
+++ b/db/chroma.py
@@ -37,14 +37,14 @@ except ImportError:  # pragma: no cover – langchain optional in minimal instal
 # Local runtime configuration -------------------------------------------------
 
 from app.config import get_settings
+from functools import lru_cache
+from jules.logging import trace
 
 # Cache the settings instance once at import time – these values are immutable
 # for the lifetime of the process and reading from the cached copy avoids the
 # relatively expensive environment parsing on every search call.
 
 settings = get_settings()
-
-from jules.logging import trace
 
 logger = logging.getLogger(__name__)
 
@@ -56,9 +56,6 @@ _embedding: EmbeddingFunction[Any] | None = None
 # ---------------------------------------------------------------------------
 # Max-Marginal Relevance helper
 # ---------------------------------------------------------------------------
-
-
-from functools import lru_cache
 
 
 @lru_cache(maxsize=1)
@@ -284,7 +281,6 @@ async def search(
     without adding a heavyweight dependency on LangChain in the hot path.
     """
 
-
     top_k = k or settings.SEARCH_TOP_K
     oversample = settings.SEARCH_MMR_OVERSAMPLE
 
@@ -303,7 +299,11 @@ async def search(
             fetch_k = top_k * oversample
             # Chroma’s LC wrapper exposes .max_marginal_relevance_search()
             return store.max_marginal_relevance_search(
-                query, k=top_k, fetch_k=fetch_k, filter=where, lambda_mult=settings.SEARCH_MMR_LAMBDA
+                query,
+                k=top_k,
+                fetch_k=fetch_k,
+                filter=where,
+                lambda_mult=settings.SEARCH_MMR_LAMBDA,
             )
 
         try:

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,0 +1,34 @@
+version: "3.9"
+
+x-debug-env: &debug-env
+  JULES_DEBUG: "1"
+
+x-debug-logging: &debug-logging
+  driver: json-file
+  options:
+    max-size: "50m"
+    max-file: "5"
+
+services:
+  jules:
+    environment:
+      <<: *debug-env
+    command:
+      - backend/cli.py
+      - run-server
+      - --debug
+    logging: *debug-logging
+
+  worker:
+    environment:
+      <<: *debug-env
+    command:
+      - worker/cli.py
+      - run-worker
+      - --debug
+    logging: *debug-logging
+
+  chroma:
+    environment:
+      RUST_LOG: debug
+    logging: *debug-logging

--- a/docs/development/debugging.md
+++ b/docs/development/debugging.md
@@ -1,0 +1,30 @@
+# Debugging Jules
+
+Jules supports a global debug mode that lifts all services to TRACE level.
+Enable it via the `JULES_DEBUG` environment variable or by using the
+`docker-compose.debug.yml` overlay.
+
+## Using the environment variable
+
+```bash
+JULES_DEBUG=1 docker compose up
+```
+
+## Using the overlay file
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.debug.yml up
+```
+
+## Log locations
+
+Each container writes coloured console output and two log files inside
+`/app/logs`. Old pairs beyond the latest ten are removed automatically.
+When running locally you can grep for TRACE lines:
+
+```bash
+grep "\"level\": " logs/*.jsonl | grep TRACE
+```
+
+Docker retains up to 50 MB × 5 rotated log files per service when the overlay
+is used.

--- a/tests/test_env_flag.py
+++ b/tests/test_env_flag.py
@@ -1,0 +1,6 @@
+from backend.app.config import Settings
+
+
+def test_env_flag_true(monkeypatch):
+    monkeypatch.setenv("JULES_DEBUG", "1")
+    assert Settings().debug is True

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,8 @@
+from jules.logging import configure_logging, TRACE
+import logging
+
+
+def test_trace_level(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    configure_logging(True)
+    assert logging.getLogger().level == TRACE

--- a/worker/__main__.py
+++ b/worker/__main__.py
@@ -1,0 +1,16 @@
+import logging
+import os
+
+from jules.logging import configure_logging
+
+from .cli import app
+
+
+def main() -> None:
+    configure_logging(debug=os.getenv("JULES_DEBUG") in {"1", "true", "yes"})
+    logging.getLogger("rq.worker").setLevel(logging.getLogger().level)
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/worker/cli.py
+++ b/worker/cli.py
@@ -1,0 +1,19 @@
+import os
+import typer
+
+app = typer.Typer(add_completion=False)
+
+
+@app.command()
+def run_worker(
+    debug: bool = typer.Option(False, "--debug/--no-debug", help="Enable TRACE logging")
+) -> None:
+    """Start the background job worker."""
+    os.environ["JULES_DEBUG"] = "1" if debug else "0"
+    # Placeholder for actual worker start logic
+    while True:
+        pass
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
## Summary
- add TRACE logging configuration and pruning
- expose debug flag via backend settings
- start logging before FastAPI app creation
- add CLI wrappers and a minimal worker package
- document debug mode and overlay compose file
- update CI to collect logs and ensure JULES_DEBUG=0
- test debug env flag and TRACE level

## Testing
- `poetry run mypy --strict .` *(fails: Duplicate module named "conftest")*
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688299127c38832d9628fae5ba8da98b